### PR TITLE
CGI::escape class names to avoid colisions in url

### DIFF
--- a/lib/shrine/plugins/encoder.rb
+++ b/lib/shrine/plugins/encoder.rb
@@ -78,7 +78,7 @@ class Shrine
 
         def callback_url
           File.join endpoint_url,
-                    record.class.name.underscore,
+                    CGI::escape(record.class.name.underscore),
                     record.id.to_s,
                     name.to_s,
                     'callback'


### PR DESCRIPTION
In example: Asset::Video becomes asset%2Fvideo not asset/video
